### PR TITLE
1. Исправлены опечатки; Деление на ноль при конвертации валют

### DIFF
--- a/admin/view/template/setting/setting.tpl
+++ b/admin/view/template/setting/setting.tpl
@@ -1115,7 +1115,7 @@ $('select[name=\'config_country_id\']').bind('change', function() {
 		url: 'index.php?route=setting/setting/country&token=<?php echo $token; ?>&country_id=' + this.value,
 		dataType: 'json',
 		beforeSend: function() {
-			$('select[name=\'country_id\']').after('<span class="wait">&nbsp;<img src="view/image/loading.gif" alt="" /></span>');
+			$('select[name=\'config_country_id\']').after('<span class="wait">&nbsp;<img src="view/image/loading.gif" alt="" /></span>');
 		},		
 		complete: function() {
 			$('.wait').remove();

--- a/catalog/controller/account/address.php
+++ b/catalog/controller/account/address.php
@@ -587,8 +587,8 @@ class ControllerAccountAddress extends Controller {
 	}
 
 	private function initGeoIp() {
-		$$google_api_key = $this->config->get('config_google_api_key');
-		$is_init = (($this->request->server['REQUEST_METHOD'] != 'POST') && $api_key);
+		$google_api_key = $this->config->get('config_google_api_key');
+		$is_init = (($this->request->server['REQUEST_METHOD'] != 'POST') && $google_api_key);
 		if ($is_init) {
 			$this->document->addScript('http://maps.google.com/maps/api/js?key='.$google_api_key.'&sensor=false&language=ru');
 			$this->document->addScript('catalog/view/javascript/jquery/geoip.ru.js');

--- a/system/library/currency.php
+++ b/system/library/currency.php
@@ -101,14 +101,13 @@ class Currency {
   	public function convert($value, $from, $to) {
 		if (isset($this->currencies[$from])) {
 			$from = $this->currencies[$from]['value'];
-		} else {
-			$from = 0;
+		} else {		  return 0;
 		}
 		
 		if (isset($this->currencies[$to])) {
 			$to = $this->currencies[$to]['value'];
 		} else {
-			$to = 0;
+			return 0;
 		}		
 		
 		return $value * ($to / $from);


### PR DESCRIPTION
1. Исправлены опечатки
2. Убрана потенциальная ошибка деления на ноль при конвертации валют

P.S. 
По п.2 - изменения в методе public function convert($value, $from, $to)
Сорри за целый файл - первый коммит в Гите и совершенно не понимаю почему именно в этом файле так :(
