### PR TITLE
Фикс показа всех категорий в поле родителя

### DIFF
--- a/admin/model/catalog/category.php
+++ b/admin/model/catalog/category.php
@@ -311,7 +311,7 @@ class ModelCatalogCategory extends Model {
 	}
 
 	public function getAllCategories() {
-		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "category c LEFT JOIN " . DB_PREFIX . "category_description cd ON (c.category_id = cd.category_id) LEFT JOIN " . DB_PREFIX . "category_to_store c2s ON (c.category_id = c2s.category_id) WHERE cd.language_id = '" . (int)$this->config->get('config_language_id') . "' AND c2s.store_id = '" . (int)$this->config->get('config_store_id') . "'  ORDER BY c.parent_id, c.sort_order, cd.name");
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "category c LEFT JOIN " . DB_PREFIX . "category_description cd ON (c.category_id = cd.category_id) LEFT JOIN " . DB_PREFIX . "category_to_store c2s ON (c.category_id = c2s.category_id) WHERE cd.language_id = '" . (int)$this->config->get('config_language_id') . "' ORDER BY c.parent_id, c.sort_order, cd.name");
 
 		$category_data = array();
 		foreach ($query->rows as $row) {


### PR DESCRIPTION
Почему-то использовался фильтр по активного магазину, но такого в админке просто нет. И получается что не показывались родительские категории для второго магазина.
