### PR TITLE
убрано подключение summernote

### DIFF
--- a/upload/admin/view/template/common/header.tpl
+++ b/upload/admin/view/template/common/header.tpl
@@ -15,9 +15,6 @@
 <script type="text/javascript" src="view/javascript/bootstrap/js/bootstrap.min.js"></script>
 <link href="view/stylesheet/bootstrap.css" type="text/css" rel="stylesheet" />
 <link href="view/javascript/font-awesome/css/font-awesome.min.css" type="text/css" rel="stylesheet" />
-<link href="view/javascript/summernote/summernote.css" rel="stylesheet" />
-<script type="text/javascript" src="view/javascript/summernote/summernote.js"></script>
-<script src="view/javascript/summernote/lang/summernote-<?php echo $lang; ?>.js"></script>
 <script src="view/javascript/jquery/datetimepicker/moment.js" type="text/javascript"></script>
 <script src="view/javascript/jquery/datetimepicker/locale/<?php echo $code; ?>.js" type="text/javascript"></script>
 <script src="view/javascript/jquery/datetimepicker/bootstrap-datetimepicker.min.js" type="text/javascript"></script>


### PR DESCRIPTION
в 2302 summernote убран из хидера и подключается непосредственно там, где используется (manufacturer_info.tpl и тд)
если не убрать - будут проблемы при использовании ckeditor в качестве основного редактора
