### PR TITLE
Update manufacturer.php

### DIFF
--- a/upload/catalog/controller/product/manufacturer.php
+++ b/upload/catalog/controller/product/manufacturer.php
@@ -239,8 +239,8 @@ class ControllerProductManufacturer extends Controller {
 					'price'       => $price,
 					'special'     => $special,
 					'tax'         => $tax,
-					'minimum'     => $result['minimum'] > 0 ? $result['minimum'] : 1,
-					'rating'      => $result['rating'],
+					'minimum'     => ($result['minimum'] > 0) ? $result['minimum'] : 1,
+					'rating'      => $rating,
 					'href'        => $this->url->link('product/product', 'manufacturer_id=' . $result['manufacturer_id'] . '&product_id=' . $result['product_id'] . $url)
 				);
 			}


### PR DESCRIPTION
Условие тернарного оператора должно быть в скобках и Опечатка на которую долго никто не обращает внимание. Если отзывы отключены, рейтинг выводиться не должен. Это и проверяет условие чуть выше, иначе зачем оно: 
if ($this->config->get('config_review_status')) {
   $rating = (int)$result['rating'];
} else {
   $rating = false;
}