### PR TITLE
Update download.php

### DIFF
--- a/upload/admin/controller/catalog/download.php
+++ b/upload/admin/controller/catalog/download.php
@@ -438,7 +438,7 @@ class ControllerCatalogDownload extends Controller {
 		if (!$json) {
 			if (!empty($this->request->files['file']['name']) && is_file($this->request->files['file']['tmp_name'])) {
 				// Sanitize the filename
-				$filename = basename(html_entity_decode($this->request->files['file']['name'], ENT_QUOTES, 'UTF-8'));
+				$filename = html_entity_decode($this->request->files['file']['name'], ENT_QUOTES, 'UTF-8');
 
 				// Validate the filename length
 				if ((utf8_strlen($filename) < 3) || (utf8_strlen($filename) > 128)) {


### PR DESCRIPTION
basename не работает с кириллицей, и обрезает имена загружаемых файлов. Если у нас Русская сборка, то мы должны иметь возможность корректно загружать и скачивать файлы на русском.