### PR TITLE
Update upload.php

### DIFF
--- a/upload/admin/controller/tool/upload.php
+++ b/upload/admin/controller/tool/upload.php
@@ -279,13 +279,13 @@ class ControllerToolUpload extends Controller {
 
 		if ($upload_info) {
 			$file = DIR_UPLOAD . $upload_info['filename'];
-			$mask = basename($upload_info['name']);
+			$mask = $upload_info['name'];
 
 			if (!headers_sent()) {
 				if (is_file($file)) {
 					header('Content-Type: application/octet-stream');
 					header('Content-Description: File Transfer');
-					header('Content-Disposition: attachment; filename="' . ($mask ? $mask : basename($file)) . '"');
+					header('Content-Disposition: attachment; filename="' . ($mask ? $mask : $file) . '"');
 					header('Content-Transfer-Encoding: binary');
 					header('Expires: 0');
 					header('Cache-Control: must-revalidate, post-check=0, pre-check=0');


### PR DESCRIPTION
basename не работает с кириллицей, и обрезает имена загружаемых файлов. Если у нас Русская сборка, то мы должны иметь возможность корректно загружать и скачивать файлы на русском.