### PR TITLE
Update download.php

### DIFF
--- a/upload/catalog/controller/account/download.php
+++ b/upload/catalog/controller/account/download.php
@@ -128,12 +128,12 @@ class ControllerAccountDownload extends Controller {
 
 		if ($download_info) {
 			$file = DIR_DOWNLOAD . $download_info['filename'];
-			$mask = basename($download_info['mask']);
+			$mask = $download_info['mask'];
 
 			if (!headers_sent()) {
 				if (file_exists($file)) {
 					header('Content-Type: application/octet-stream');
-					header('Content-Disposition: attachment; filename="' . ($mask ? $mask : basename($file)) . '"');
+					header('Content-Disposition: attachment; filename="' . ($mask ? $mask : $file) . '"');
 					header('Expires: 0');
 					header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 					header('Pragma: public');


### PR DESCRIPTION
basename не работает с кириллицей, и обрезает имена загружаемых файлов. Если у нас Русская сборка, то мы должны иметь возможность корректно загружать и скачивать файлы на русском.