### PR TITLE
Выборка OCMOD с сортировкой по дате

### DIFF
--- a/upload/admin/controller/extension/modification.php
+++ b/upload/admin/controller/extension/modification.php
@@ -123,7 +123,7 @@ class ControllerExtensionModification extends Controller {
 			}
 
 			// Get the default modification file
-			$results = $this->model_extension_modification->getModifications();
+			$results = $this->model_extension_modification->getModifications(array('sort'=>'date_added', 'order'=>'ASC'));
 
 			foreach ($results as $result) {
 				if ($result['status']) {


### PR DESCRIPTION
При сбросе кэша OCMOD и его применению, обновления брались отслортированными по имени. Из-за чего нарушалась последовательность загрузки OCMOD и могла приводить к неожиданным конфликтам.